### PR TITLE
make tail a btree of jumps

### DIFF
--- a/murmur128_amd64.s
+++ b/murmur128_amd64.s
@@ -85,37 +85,39 @@ tail:
 
 	XORQ AX, AX
 
-	// poor man's jump table
-	DECQ CX
-	JZ   tail1
-	DECQ CX
-	JZ   tail2
-	DECQ CX
-	JZ   tail3
-	DECQ CX
-	JZ   tail4
-	DECQ CX
-	JZ   tail5
-	DECQ CX
-	JZ   tail6
-	DECQ CX
-	JZ   tail7
-	DECQ CX
+	// poor man's btree jump table
+	SUBQ $8, CX
 	JZ   tail8
-	DECQ CX
-	JZ   tail9
-	DECQ CX
-	JZ   tail10
-	DECQ CX
-	JZ   tail11
-	DECQ CX
+	JG   over8
+	ADDQ $4, CX
+	JZ   tail4
+	JG   over4
+	ADDQ $2, CX
+	JL   tail1
+	JZ   tail2
+	JMP  tail3
+
+over4:
+	SUBQ $2, CX
+	JL   tail5
+	JZ   tail6
+	JMP  tail7
+
+over8:
+	SUBQ $4, CX
 	JZ   tail12
-	DECQ CX
-	JZ   tail13
-	DECQ CX
+	JG   over12
+	ADDQ $2, CX
+	JL   tail9
+	JZ   tail10
+	JMP  tail11
+
+over12:
+	SUBQ $2, CX
+	JL   tail13
 	JZ   tail14
 
-tail15:  // no jump
+tail15:
 	MOVBQZX 14(SI)(BP*1), AX
 	SALQ    $16, AX
 

--- a/murmur32_amd64.s
+++ b/murmur32_amd64.s
@@ -53,9 +53,8 @@ tail:
 
 	XORQ AX, AX
 
-	DECL CX
-	JZ   tail1
-	DECL CX
+	SUBQ $2, CX
+	JL   tail1
 	JZ   tail2
 
 tail3:  // no jump


### PR DESCRIPTION
... for fun.

This takes 128 tail from a spread of 10ns to 15ns to 10 to 12.5.

... every nanosecond matters

So, while this is slower for the tail length 1, 2, and 3 cases, it is
equal or faster for all other cases.

```
BenchmarkBase32-32         6.07          5.74          -5.44%
BenchmarkLoop32-32         6.79          6.66          -1.91%
BenchmarkTail32_1-32       6.71          6.77          +0.89%
BenchmarkTail32_2-32       6.62          6.26          -5.44%
BenchmarkTail32_3-32       6.86          6.90          +0.58%
BenchmarkBase128-32        8.26          8.23          -0.36%
BenchmarkLoop128-32        12.1          12.1          +0.00%
BenchmarkTail128_1-32      10.0          11.1          +11.00%
BenchmarkTail128_2-32      9.96          11.5          +15.46%
BenchmarkTail128_3-32      10.6          11.7          +10.38%
BenchmarkTail128_4-32      10.8          10.5          -2.78%
BenchmarkTail128_5-32      12.0          11.4          -5.00%
BenchmarkTail128_6-32      11.7          11.8          +0.85%
BenchmarkTail128_7-32      12.6          11.9          -5.56%
BenchmarkTail128_8-32      11.8          9.86          -16.44%
BenchmarkTail128_9-32      13.0          11.9          -8.46%
BenchmarkTail128_10-32     13.2          11.8          -10.61%
BenchmarkTail128_11-32     13.8          12.2          -11.59%
BenchmarkTail128_12-32     13.8          11.0          -20.29%
BenchmarkTail128_13-32     14.5          12.3          -15.17%
BenchmarkTail128_14-32     14.8          12.3          -16.89%
BenchmarkTail128_15-32     15.1          12.7          -15.89%
```