### PR TITLE
Add Go compiler directive 'noescape' to assembly implementations

### DIFF
--- a/murmur128_decl.go
+++ b/murmur128_decl.go
@@ -2,12 +2,16 @@
 
 package murmur3
 
+//go:noescape
+
 // Sum128 returns the murmur3 sum of data. It is equivalent to the following
 // sequence (without the extra burden and the extra allocation):
 //     hasher := New128()
 //     hasher.Write(data)
 //     return hasher.Sum128()
 func Sum128(data []byte) (h1 uint64, h2 uint64)
+
+//go:noescape
 
 // SeedSum128 returns the murmur3 sum of data with digests initialized to seed1
 // and seed2.
@@ -16,8 +20,12 @@ func Sum128(data []byte) (h1 uint64, h2 uint64)
 // behavior, use the same, uint32-max seed for seed1 and seed2.
 func SeedSum128(seed1, seed2 uint64, data []byte) (h1 uint64, h2 uint64)
 
+//go:noescape
+
 // StringSum128 is the string version of Sum128.
 func StringSum128(data string) (h1 uint64, h2 uint64)
+
+//go:noescape
 
 // SeedStringSum128 is the string version of SeedSum128.
 func SeedStringSum128(seed1, seed2 uint64, data string) (h1 uint64, h2 uint64)

--- a/murmur32_decl.go
+++ b/murmur32_decl.go
@@ -2,6 +2,8 @@
 
 package murmur3
 
+//go:noescape
+
 // Sum32 returns the murmur3 sum of data. It is equivalent to the following
 // sequence (without the extra burden and the extra allocation):
 //     hasher := New32()
@@ -9,12 +11,18 @@ package murmur3
 //     return hasher.Sum32()
 func Sum32(data []byte) (h1 uint32)
 
+//go:noescape
+
 // SeedSum32 returns the murmur3 sum of data with the digest initialized to
 // seed.
 func SeedSum32(seed uint32, data []byte) (h1 uint32)
 
+//go:noescape
+
 // StringSum32 is the string version of Sum32.
 func StringSum32(data string) (h1 uint32)
+
+//go:noescape
 
 // SeedStringSum32 is the string version of SeedSum32.
 func SeedStringSum32(seed uint32, data string) (h1 uint32)


### PR DESCRIPTION
Without this directive Go considers that `data []byte` escapes from the
function, and forces allocation on the heap even for values which can
perfectly stay on the stack.

This removes extra allocation when value passed in is not on the heap
already.

See also: https://github.com/golang/go/issues/4099