### PR TITLE
Make strslice more portable

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -64,8 +64,9 @@ func (d *digest) Reset() {
 
 func strslice(slice []byte) string {
 	var str string
+	slicehdr := ((*reflect.SliceHeader)(unsafe.Pointer(&slice)))
 	strhdr := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	strhdr.Data = ((*reflect.SliceHeader)(unsafe.Pointer(&slice))).Data
-	strhdr.Len = len(slice)
+	strhdr.Data = slicehdr.Data
+	strhdr.Len = slicehdr.Len
 	return str
 }


### PR DESCRIPTION
TinyGo uses a slightly different layout of strings and slices (which is only relevant on AVR): it uses uintptr instead of int for the Len and Cap fields. The `reflect.StringHeader` and `reflect.SliceHeader` were never portable to begin with, but this change makes the code slightly more portable to include TinyGo.

I've checked the performance with `go test -bench=Strslice` but the difference appears to be well within the noise.

Please see https://github.com/tinygo-org/tinygo/issues/1284 for discussion on this issue.