### PR TITLE
avoid amd64 hand rolled go asm on gccgo

### DIFF
--- a/murmur128_amd64.s
+++ b/murmur128_amd64.s
@@ -1,4 +1,5 @@
-// +build go1.5,amd64
+//go:build go1.5 && amd64 && !gccgo
+// +build go1.5,amd64,!gccgo
 
 // SeedSum128(seed1, seed2 uint64, data []byte) (h1 uint64, h2 uint64)
 TEXT ·SeedSum128(SB), $0-56

--- a/murmur128_decl.go
+++ b/murmur128_decl.go
@@ -1,4 +1,5 @@
-// +build go1.5,amd64
+//go:build go1.5 && amd64 && !gccgo
+// +build go1.5,amd64,!gccgo
 
 package murmur3
 
@@ -6,9 +7,10 @@ package murmur3
 
 // Sum128 returns the murmur3 sum of data. It is equivalent to the following
 // sequence (without the extra burden and the extra allocation):
-//     hasher := New128()
-//     hasher.Write(data)
-//     return hasher.Sum128()
+//
+//	hasher := New128()
+//	hasher.Write(data)
+//	return hasher.Sum128()
 func Sum128(data []byte) (h1 uint64, h2 uint64)
 
 //go:noescape

--- a/murmur128_gen.go
+++ b/murmur128_gen.go
@@ -1,5 +1,5 @@
-//go:build !go1.5 || !amd64
-// +build !go1.5 !amd64
+//go:build !go1.5 || !amd64 || gccgo
+// +build !go1.5 !amd64 gccgo
 
 package murmur3
 


### PR DESCRIPTION
gccgo doesn't like Go assembly

Closes #11